### PR TITLE
Added .gitattributes for line ending handling

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,20 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+*.cs     text
+*.shader text
+*.txt    text
+*.json   text
+*.xml    text
+*.asset  text
+*.meta   text
+*.unity  text
+
+# Denote all files that are truly binary and should not be modified.
+*.png    binary
+*.jpg    binary
+*.fbx    binary
+*.dll    binary
+*.exe    binary


### PR DESCRIPTION
Complete this pull request first.  Supposed to fix this issue: "warning: in the working copy of 'Assets/TextMesh Pro/Examples & Extras/Fonts/Anton OFL.txt', CRLF will be replaced by LF the next time Git touches it" before committing those files.